### PR TITLE
adding tracker HighPt ID (used in B2G analyses) branch to the tnp tree

### DIFF
--- a/python/common_variables_cff.py
+++ b/python/common_variables_cff.py
@@ -154,6 +154,10 @@ MuonIDFlags = cms.PSet(
                         "numberOfMatchedStations > 1 && track.hitPattern.numberOfValidPixelHits > 0 && "+
                         "track.hitPattern.trackerLayersWithMeasurement > 5 && abs(dB) < 0.2 && "+
                         "(tunePMuonBestTrack.ptError / tunePMuonBestTrack.pt) < 0.3"),
+    tkHighPt  = cms.string("isTrackerMuon &&  track.isNonnull && "+
+                        "numberOfMatchedStations > 1 && track.hitPattern.numberOfValidPixelHits > 0 && "+
+                        "track.hitPattern.trackerLayersWithMeasurement > 5 && abs(dB) < 0.2 && "+
+                        "(tunePMuonBestTrack.ptError / tunePMuonBestTrack.pt) < 0.3"),
     HWWID =  cms.string("( ((isGlobalMuon() && "
                         "    globalTrack.normalizedChi2 <10 &&" +
                         "    globalTrack.hitPattern.numberOfValidMuonHits > 0 && " + 


### PR DESCRIPTION
Sorry for the delay. The tracker HighPt ID branch is approved to be added in the tree at the Muon POG meeting on Aug 8 (indico: https://indico.cern.ch/event/561921/)
